### PR TITLE
perf(core): prevent callback changes with useCallback

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -4,6 +4,7 @@
     "browser": true
   },
   "parser": "@typescript-eslint/parser",
+  "plugins": ["react-hooks"],
   "extends": [
     "plugin:react/recommended",
     "prettier/@typescript-eslint",
@@ -23,8 +24,10 @@
     }
   },
   "rules": {
+    "sort-imports": ["error"],
     "react/prop-types": "off",
-    "sort-imports": ["error"]
+    "react-hooks/rules-of-hooks": "error",
+    "react-hooks/exhaustive-deps": "error"
   },
   "overrides": [
     {

--- a/package-lock.json
+++ b/package-lock.json
@@ -8998,6 +8998,12 @@
         }
       }
     },
+    "eslint-plugin-react-hooks": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-2.5.1.tgz",
+      "integrity": "sha512-Y2c4b55R+6ZzwtTppKwSmK/Kar8AdLiC2f9NADCuxbcTgPPg41Gyqa6b9GppgXSvCtkRw43ZE86CT5sejKC6/g==",
+      "dev": true
+    },
     "eslint-scope": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.0.0.tgz",
@@ -17533,7 +17539,7 @@
         },
         "onetime": {
           "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
+          "resolved": "http://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
           "integrity": "sha1-ofeDj4MUxRbwXs78vEzP4EtO14k=",
           "dev": true
         },
@@ -17754,7 +17760,7 @@
         },
         "onetime": {
           "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
+          "resolved": "http://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
           "integrity": "sha1-ofeDj4MUxRbwXs78vEzP4EtO14k=",
           "dev": true
         },
@@ -19138,7 +19144,7 @@
         },
         "onetime": {
           "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
+          "resolved": "http://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
           "integrity": "sha1-ofeDj4MUxRbwXs78vEzP4EtO14k=",
           "dev": true
         },

--- a/package.json
+++ b/package.json
@@ -79,6 +79,7 @@
     "eslint-plugin-jest": "^23.8.2",
     "eslint-plugin-prettier": "^3.1.2",
     "eslint-plugin-react": "^7.19.0",
+    "eslint-plugin-react-hooks": "^2.5.1",
     "file-loader": "^1.1.11",
     "husky": "^4.2.3",
     "immer": "^6.0.2",


### PR DESCRIPTION
callbacks returned by useEditable weren't being memoized resulting in comparisons failing. This should fix their perf issues without additional bugs.